### PR TITLE
add .travis file and fix for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: cpp
+
+script:
+  - mkdir build && cd build
+  - cmake .. -DENABLE_GLIB=OFF -DCMAKE_INSTALL_PREFIX= -DBUILD_GTK_TESTS=OFF -DENABLE_QT5=OFF -DWITH_GObjectIntrospection=OFF -DENABLE_CMS=none
+  - make
+  - mkdir ../dist
+  - make DESTDIR="$PWD/../dist" install
+
+matrix:
+  include:
+    - dist: trusty
+      compiler: clang
+    - dist: trusty
+      compiler: gcc     
+    - os: osx
+      osx_image: xcode9.2
+      before_install:
+        - brew install poppler --build-from-source
+        - brew remove poppler
+    - os: osx
+      osx_image: xcode8.3
+      before_install:
+        - brew install poppler --build-from-source
+        - brew remove poppler
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:aacid/openjp2trusty'    
+    packages:
+      - cmake
+      - libglib2.0-dev
+      - libgtk2.0-dev
+      - libfontconfig1-dev
+      - libcairo2-dev
+      - libjpeg-dev
+      - libpng-dev
+      - libtiff-dev
+      - liblcms2-dev
+      - libfreetype6-dev
+      - libopenjp2-7-dev

--- a/goo/gfile.cc
+++ b/goo/gfile.cc
@@ -687,7 +687,7 @@ GooFile::GooFile(int fdA)
 {
     struct stat statbuf;
     fstat(fd, &statbuf);
-    modifiedTimeOnOpen = statbuf.st_mtim;
+    modifiedTimeOnOpen.tv_sec = statbuf.st_mtime;
 }
 
 bool GooFile::modificationTimeChangedSinceOpen() const
@@ -695,7 +695,7 @@ bool GooFile::modificationTimeChangedSinceOpen() const
     struct stat statbuf;
     fstat(fd, &statbuf);
 
-    return modifiedTimeOnOpen.tv_sec != statbuf.st_mtim.tv_sec || modifiedTimeOnOpen.tv_nsec != statbuf.st_mtim.tv_nsec;
+    return modifiedTimeOnOpen.tv_sec != statbuf.st_mtime || modifiedTimeOnOpen.tv_nsec != statbuf.st_mtime;
 }
 
 #endif // _WIN32


### PR DESCRIPTION
Add travis config. Also fixes an existing osx bug in the master branch (see mailing list).

To enable travis, you need to login to https://travis-ci.org/ and set the activate the switch for your `mpsuzuki/poppler` repository